### PR TITLE
Update Kamon, Scala and other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-- 2.12.8
-- 2.11.12
+- 2.13.1
+- 2.12.10
 jdk:
 - oraclejdk8
 ignore:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 Defines a core tagless dsl for incrementing/decrementing/etc metrics.
 
+As of version 0.2.0, tagless-metrics supports Kamon 2.x for Scala 2.12 and
+2.13.
+
+Kamon 1.x is supported by version 0.1.0 of tagless-metrics and is
+availale for Scala 2.11 and 2.12 ... see below for further details.
+
 ## tagless-metrics-kamon
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.13)
 
 Defines kamon-integration via the dsl.
+
 
 ## Include
 
@@ -43,6 +50,25 @@ def printAndIncrementMetric[F[_] : Sync : IncrementMeric[?[_], Counter]] : F[Uni
     _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status", "before"))
     _ <- Sync[F].delay { println("Hello world" }
     _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status", "after"))
+  } yield ()
+
+```
+
+## Older versions
+
+Kamon 1.x is supported by version 0.1.0 of tagless-metrics and is
+availale for Scala 2.11 and 2.12. Inclusion and usage are as above, but note
+that syntax follows the earlier Kamon release with `refine` used in place of
+`withTag`. Consequently the preceding example would be written,
+
+```
+val helloWorldCounter = Counter("hello-world-counter")
+
+def printAndIncrementMetric[F[_] : Sync : IncrementMeric[?[_], Counter]] : F[Unit] =
+  for {
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.refine("status" -> "before"))
+    _ <- Sync[F].delay { println("Hello world" }
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.refine("status" -> "after"))
   } yield ()
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## tagless-metrics-core
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-core_2.12)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-core_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-core_2.13)
 
 Defines a core tagless dsl for incrementing/decrementing/etc metrics.
 
 ## tagless-metrics-kamon
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.12)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.novelfs/tagless-metrics-kamon_2.13)
 
 Defines kamon-integration via the dsl.
 
@@ -15,8 +15,8 @@ Defines kamon-integration via the dsl.
 Add dependencies to `built.sbt`
 
 ```
-libraryDependencies += "org.novelfs" %% "tagless-metrics-core" % "0.1.2"
-libraryDependencies += "org.novelfs" %% "tagless-metrics-kamon" % "0.1.2"
+libraryDependencies += "org.novelfs" %% "tagless-metrics-core" % "0.2.0"
+libraryDependencies += "org.novelfs" %% "tagless-metrics-kamon" % "0.2.0"
 ```
 
 ## Usage
@@ -40,9 +40,9 @@ val helloWorldCounter = Counter("hello-world-counter")
 
 def printAndIncrementMetric[F[_] : Sync : IncrementMeric[?[_], Counter]] : F[Unit] =
   for {
-    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.refine("status" -> "before"))
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status" -> "before"))
     _ <- Sync[F].delay { println("Hello world" }
-    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.refine("status" -> "after"))
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status" -> "after"))
   } yield ()
 
 ```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ val helloWorldCounter = Counter("hello-world-counter")
 
 def printAndIncrementMetric[F[_] : Sync : IncrementMeric[?[_], Counter]] : F[Unit] =
   for {
-    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status" -> "before"))
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status", "before"))
     _ <- Sync[F].delay { println("Hello world" }
-    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status" -> "after"))
+    _ <- IncrementMetric[F, Counter].increment(helloWorldCounter.withTag("status", "after"))
   } yield ()
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,11 @@ name := "tagless-metrics"
 
 version := "0.2.0"
 
-val ScalaVersion = "2.13.1"
+inThisBuild(Seq(
+  organization := "org.novelfs",
+  scalaVersion := "2.13.1",
+  crossScalaVersions := Seq("2.12.10", scalaVersion.value)
+))
 
 lazy val noPublishSettings = Seq(
   publish := {},
@@ -13,8 +17,6 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val commonSettings = Seq(
-  scalaVersion := ScalaVersion,
-  organization := "org.novelfs",
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import ReleaseTransformations._
 
 name := "tagless-metrics"
 
-version := "0.1.2"
+version := "0.2.0"
 
-val ScalaVersion = "2.12.8"
+val ScalaVersion = "2.13.1"
 
 lazy val noPublishSettings = Seq(
   publish := {},
@@ -15,7 +15,7 @@ lazy val noPublishSettings = Seq(
 lazy val commonSettings = Seq(
   scalaVersion := ScalaVersion,
   organization := "org.novelfs",
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value)
@@ -41,45 +41,6 @@ lazy val commonSettings = Seq(
   ),
   pomIncludeRepository := { _ => false },
   publishMavenStyle := true,
-  scalacOptions ++= Seq(
-    "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-    "-encoding", "utf-8",                // Specify character encoding used by source files.
-    "-explaintypes",                     // Explain type errors in more detail.
-    "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-    "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
-    "-language:higherKinds",             // Allow higher-kinded types
-    "-language:implicitConversions",     // Allow definition of implicit functions called views
-    "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-    "-Xfuture",                          // Turn on future language features.
-    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit",            // Option.apply used implicit view.
-    "-Xlint:package-object-classes",     // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-    "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    "-Ypartial-unification",             // Enable partial unification in type constructor inference
-    "-Ywarn-dead-code",                  // Warn when dead code is identified.
-    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-    "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
-  )
 )
 
 lazy val core =
@@ -95,12 +56,12 @@ lazy val kamon =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "io.kamon"       %% "kamon-core"        % "1.1.6",
-        "org.typelevel"  %% "cats-effect"       % "1.2.0",
-        "io.kamon"       %% "kamon-testkit"     % "1.1.1"  % Test,
-        "org.scalacheck" %% "scalacheck"        % "1.14.0" % Test,
-        "org.scalactic"  %% "scalactic"         % "3.0.5"  % Test,
-        "org.scalatest"  %% "scalatest"         % "3.0.5"  % Test
+        "io.kamon"       %% "kamon-bundle"      % "2.0.4",
+        "org.typelevel"  %% "cats-effect"       % "2.1.0",
+        "io.kamon"       %% "kamon-testkit"     % "2.0.4"  % Test,
+        "org.scalacheck" %% "scalacheck"        % "1.14.3" % Test,
+        "org.scalactic"  %% "scalactic"         % "3.0.8"  % Test,
+        "org.scalatest"  %% "scalatest"         % "3.0.8"  % Test,
       ),
       name := "tagless-metrics-kamon",
     )
@@ -131,5 +92,3 @@ releaseProcess := Seq[ReleaseStep](
   publishArtifacts,
   releaseStepCommand("sonatypeRelease")
 )
-
-

--- a/core/src/main/scala/org/novelfs/taglessmetrics/GaugeMetric.scala
+++ b/core/src/main/scala/org/novelfs/taglessmetrics/GaugeMetric.scala
@@ -1,0 +1,10 @@
+package org.novelfs.taglessmetrics
+
+trait GaugeMetric[F[_], TMetric] {
+  def raise(n : Double)(metric: TMetric) : F[Unit]
+  def lower(n : Double)(metric: TMetric) : F[Unit]
+}
+
+object GaugeMetric {
+  def apply[F[_], TMetric](implicit gaugeMetric: GaugeMetric[F, TMetric]): GaugeMetric[F, TMetric] = gaugeMetric
+}

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Counter.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Counter.scala
@@ -1,12 +1,20 @@
 package org.novelfs.taglessmetrics.kamon
 
-final case class Counter(name : String, tags : Map[String, String])
+import kamon.tag.TagSet
+
+final case class Counter(name : String, tags : TagSet)
 
 object Counter {
-  def apply(name: String): Counter = new Counter(name, Map.empty)
+  def apply(name: String): Counter = new Counter(name, TagSet.Empty)
 
   implicit class CounterOps(val counter: Counter) extends AnyVal {
-    def refine(tag : (String, String)) : Counter =
-      counter.copy(tags = counter.tags + tag)
+    def withTag(key: String, value: String) : Counter =
+      counter.copy(tags = counter.tags.withTag(key, value))
+
+    def withTag(key: String, value: Boolean) : Counter =
+      counter.copy(tags = counter.tags.withTag(key, value))
+
+    def withTag(key: String, value: Long) : Counter =
+      counter.copy(tags = counter.tags.withTag(key, value))
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Gauge.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Gauge.scala
@@ -1,12 +1,20 @@
 package org.novelfs.taglessmetrics.kamon
 
-final case class Gauge(name : String, tags : Map[String, String])
+import kamon.tag.TagSet
+
+final case class Gauge(name : String, tags : TagSet)
 
 object Gauge {
-  def apply(name: String): Gauge = new Gauge(name, Map.empty)
+  def apply(name: String): Gauge = new Gauge(name, TagSet.Empty)
 
   implicit class GaugeOps(val gauge: Gauge) extends AnyVal {
-    def refine(tag : (String, String)) : Gauge =
-      gauge.copy(tags = gauge.tags + tag)
+    def withTag(key: String, value: String) : Gauge =
+      gauge.copy(tags = gauge.tags.withTag(key, value))
+
+    def withTag(key: String, value: Boolean) : Gauge =
+      gauge.copy(tags = gauge.tags.withTag(key, value))
+
+    def withTag(key: String, value: Long) : Gauge =
+      gauge.copy(tags = gauge.tags.withTag(key, value))
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Histogram.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Histogram.scala
@@ -1,12 +1,20 @@
 package org.novelfs.taglessmetrics.kamon
 
-final case class Histogram(name : String, tags : Map[String, String])
+import kamon.tag.TagSet
+
+final case class Histogram(name : String, tags : TagSet)
 
 object Histogram {
-  def apply(name: String): Histogram = new Histogram(name, Map.empty)
+  def apply(name: String): Histogram = new Histogram(name, TagSet.Empty)
 
   implicit class THistogramOps(val hist: Histogram) extends AnyVal {
-    def refine(tag : (String, String)) : Histogram =
-      hist.copy(tags = hist.tags + tag)
+    def withTag(key: String, value: String) : Histogram =
+      hist.copy(tags = hist.tags.withTag(key, value))
+
+    def withTag(key: String, value: Boolean) : Histogram =
+      hist.copy(tags = hist.tags.withTag(key, value))
+
+    def withTag(key: String, value: Long) : Histogram =
+      hist.copy(tags = hist.tags.withTag(key, value))
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/RangeSampler.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/RangeSampler.scala
@@ -1,12 +1,20 @@
 package org.novelfs.taglessmetrics.kamon
 
-final case class RangeSampler(name : String, tags : Map[String, String])
+import kamon.tag.TagSet
+
+final case class RangeSampler(name : String, tags : TagSet)
 
 object RangeSampler {
-  def apply(name: String): RangeSampler = new RangeSampler(name, Map.empty)
+  def apply(name: String): RangeSampler = new RangeSampler(name, TagSet.Empty)
 
   implicit class RangeSamplerOps(val rangeSampler: RangeSampler) extends AnyVal {
-    def refine(tag : (String, String)) : RangeSampler =
-      rangeSampler.copy(tags = rangeSampler.tags + tag)
+    def withTag(key: String, value: String) : RangeSampler =
+      rangeSampler.copy(tags = rangeSampler.tags.withTag(key, value))
+
+    def withTag(key: String, value: Boolean) : RangeSampler =
+      rangeSampler.copy(tags = rangeSampler.tags.withTag(key, value))
+
+    def withTag(key: String, value: Long) : RangeSampler =
+      rangeSampler.copy(tags = rangeSampler.tags.withTag(key, value))
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Timer.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/Timer.scala
@@ -1,12 +1,20 @@
 package org.novelfs.taglessmetrics.kamon
 
-final case class Timer(name : String, tags : Map[String, String])
+import kamon.tag.TagSet
+
+final case class Timer(name : String, tags : TagSet)
 
 object Timer {
-  def apply(name: String): Timer = new Timer(name, Map.empty)
+  def apply(name: String): Timer = new Timer(name, TagSet.Empty)
 
   implicit class TimerOps(val timer: Timer) extends AnyVal {
-    def refine(tag : (String, String)) : Timer =
-      timer.copy(tags = timer.tags + tag)
+    def withTag(key: String, value: String) : Timer =
+      timer.copy(tags = timer.tags.withTag(key, value))
+
+    def withTag(key: String, value: Boolean) : Timer =
+      timer.copy(tags = timer.tags.withTag(key, value))
+
+    def withTag(key: String, value: Long) : Timer =
+      timer.copy(tags = timer.tags.withTag(key, value))
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/DecrementMetricInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/DecrementMetricInstances.scala
@@ -1,5 +1,6 @@
 package org.novelfs.taglessmetrics.kamon.instances
 
+import cats.implicits._
 import cats.effect.Sync
 import org.novelfs.taglessmetrics.DecrementMetric
 import org.novelfs.taglessmetrics.kamon.{Gauge, RangeSampler}
@@ -9,24 +10,24 @@ trait DecrementMetricInstances {
   implicit def decrementGauge[F[_] : Sync]: DecrementMetric[F, Gauge] = new DecrementMetric[F, Gauge] {
     override def decrement(metric: Gauge): F[Unit] =
       Sync[F].delay {
-        Kamon.gauge(metric.name).refine(metric.tags).decrement()
-      }
+        Kamon.gauge(metric.name).withTags(metric.tags).decrement()
+      }.void
 
     override def decrementTimes(n: Long)(metric: Gauge): F[Unit] =
       Sync[F].delay {
-        Kamon.gauge(metric.name).refine(metric.tags).decrement(n)
-      }
+        Kamon.gauge(metric.name).withTags(metric.tags).decrement(n.toDouble)
+      }.void
   }
 
   implicit def decrementRangeSampler[F[_] : Sync]: DecrementMetric[F, RangeSampler] = new DecrementMetric[F, RangeSampler] {
     override def decrement(metric: RangeSampler): F[Unit] =
       Sync[F].delay {
-        Kamon.rangeSampler(metric.name).refine(metric.tags).decrement()
-      }
+        Kamon.rangeSampler(metric.name).withTags(metric.tags).decrement()
+      }.void
 
     override def decrementTimes(n: Long)(metric: RangeSampler): F[Unit] =
       Sync[F].delay {
-        Kamon.rangeSampler(metric.name).refine(metric.tags).decrement(n)
-      }
+        Kamon.rangeSampler(metric.name).withTags(metric.tags).decrement(n)
+      }.void
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/GaugeMetricInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/GaugeMetricInstances.scala
@@ -1,0 +1,21 @@
+package org.novelfs.taglessmetrics.kamon.instances
+
+import cats.implicits._
+import _root_.kamon.Kamon
+import cats.effect.Sync
+import org.novelfs.taglessmetrics.GaugeMetric
+import org.novelfs.taglessmetrics.kamon.Gauge
+
+trait GaugeMetricInstances {
+  implicit def gaugeInstance[F[_] : Sync]: GaugeMetric[F, Gauge] = new GaugeMetric[F, Gauge] {
+    override def raise(n: Double)(metric: Gauge): F[Unit] =
+      Sync[F].delay {
+        Kamon.gauge(metric.name).withTags(metric.tags).increment(n)
+      }.void
+
+    override def lower(n: Double)(metric: Gauge): F[Unit] =
+      Sync[F].delay {
+        Kamon.gauge(metric.name).withTags(metric.tags).decrement(n)
+      }.void
+  }
+}

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/HistogramMetricInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/HistogramMetricInstances.scala
@@ -1,5 +1,6 @@
 package org.novelfs.taglessmetrics.kamon.instances
 
+import cats.implicits._
 import cats.effect.Sync
 import org.novelfs.taglessmetrics.HistogramMetric
 import org.novelfs.taglessmetrics.kamon.Histogram
@@ -9,12 +10,12 @@ trait HistogramMetricInstances {
   implicit def histogramHistogram[F[_] : Sync] = new HistogramMetric[F, Histogram] {
     override def record(value: Long)(metric: Histogram): F[Unit] =
       Sync[F].delay {
-        Kamon.histogram(metric.name).refine(metric.tags).record(value)
-      }
+        Kamon.histogram(metric.name).withTags(metric.tags).record(value)
+      }.void
 
     override def recordTimes(times: Long)(value: Long)(metric: Histogram): F[Unit] =
       Sync[F].delay {
-        Kamon.histogram(metric.name).refine(metric.tags).record(value, times)
-      }
+        Kamon.histogram(metric.name).withTags(metric.tags).record(value, times)
+      }.void
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/IncrementMetricInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/IncrementMetricInstances.scala
@@ -1,6 +1,7 @@
 package org.novelfs.taglessmetrics.kamon.instances
 
 import _root_.kamon.Kamon
+import cats.implicits._
 import cats.effect.Sync
 import org.novelfs.taglessmetrics.IncrementMetric
 import org.novelfs.taglessmetrics.kamon.{Counter, Gauge, RangeSampler}
@@ -9,36 +10,36 @@ trait IncrementMetricInstances {
   implicit def incrementCounter[F[_] : Sync]: IncrementMetric[F, Counter] = new IncrementMetric[F, Counter] {
     override def increment(metric: Counter): F[Unit] =
       Sync[F].delay {
-        Kamon.counter(metric.name).refine(metric.tags).increment()
-      }
+        Kamon.counter(metric.name).withTags(metric.tags).increment()
+      }.void
 
     override def incrementTimes(n: Long)(metric: Counter): F[Unit] =
       Sync[F].delay {
-        Kamon.counter(metric.name).refine(metric.tags).increment(n)
-      }
+        Kamon.counter(metric.name).withTags(metric.tags).increment(n)
+      }.void
   }
 
   implicit def incrementGauge[F[_] : Sync]: IncrementMetric[F, Gauge] = new IncrementMetric[F, Gauge] {
     override def increment(metric: Gauge): F[Unit] =
       Sync[F].delay {
-        Kamon.gauge(metric.name).refine(metric.tags).increment()
-      }
-    
+        Kamon.gauge(metric.name).withTags(metric.tags).increment()
+      }.void
+
     override def incrementTimes(n: Long)(metric: Gauge): F[Unit] =
       Sync[F].delay {
-        Kamon.gauge(metric.name).refine(metric.tags).increment(n)
-      }
+        Kamon.gauge(metric.name).withTags(metric.tags).increment(n.toDouble)
+      }.void
   }
 
   implicit def incrementRangeSampler[F[_] : Sync]: IncrementMetric[F, RangeSampler] = new IncrementMetric[F, RangeSampler] {
     override def increment(metric: RangeSampler): F[Unit] =
       Sync[F].delay {
-        Kamon.rangeSampler(metric.name).refine(metric.tags).increment()
-      }
+        Kamon.rangeSampler(metric.name).withTags(metric.tags).increment()
+      }.void
 
     override def incrementTimes(n: Long)(metric: RangeSampler): F[Unit] =
       Sync[F].delay {
-        Kamon.rangeSampler(metric.name).refine(metric.tags).increment(n)
-      }
+        Kamon.rangeSampler(metric.name).withTags(metric.tags).increment(n)
+      }.void
   }
 }

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/TimerMetricInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/TimerMetricInstances.scala
@@ -10,7 +10,7 @@ trait TimerMetricInstances {
   implicit def timerTimer[F[_] : Sync] : TimerMetric[F, Timer]= new TimerMetric[F, Timer] {
     override def measure[A](op: F[A])(metric: Timer): F[A] =
       for {
-        started <- Sync[F].delay{ Kamon.timer(metric.name).refine(metric.tags).start() }
+        started <- Sync[F].delay{ Kamon.timer(metric.name).withTags(metric.tags).start() }
         result <- op
         _ <- Sync[F].delay { started.stop() }
       } yield result

--- a/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/all/AllInstances.scala
+++ b/kamon/src/main/scala/org/novelfs/taglessmetrics/kamon/instances/all/AllInstances.scala
@@ -1,5 +1,5 @@
 package org.novelfs.taglessmetrics.kamon.instances.all
 
-import org.novelfs.taglessmetrics.kamon.instances.{DecrementMetricInstances, HistogramMetricInstances, IncrementMetricInstances, TimerMetricInstances}
+import org.novelfs.taglessmetrics.kamon.instances.{DecrementMetricInstances, HistogramMetricInstances, IncrementMetricInstances, TimerMetricInstances, GaugeMetricInstances}
 
-trait AllInstances extends DecrementMetricInstances with HistogramMetricInstances with IncrementMetricInstances with TimerMetricInstances
+trait AllInstances extends DecrementMetricInstances with HistogramMetricInstances with IncrementMetricInstances with TimerMetricInstances with GaugeMetricInstances

--- a/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/CounterSpec.scala
+++ b/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/CounterSpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.novelfs.taglessmetrics.IncrementMetric
 import org.novelfs.taglessmetrics.kamon.instances.all._
 import _root_.kamon.Kamon
-import _root_.kamon.testkit.MetricInspection
+import _root_.kamon.testkit.InstrumentInspection
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class CounterSpec extends FlatSpec with Matchers with MetricInspection with GeneratorDrivenPropertyChecks {
+class CounterSpec extends FlatSpec with Matchers with InstrumentInspection.Syntax with ScalaCheckDrivenPropertyChecks {
   val positiveInt = Gen.posNum[Int]
 
   "increment" should "increment the metric the number of times it is called" in {
@@ -18,7 +18,7 @@ class CounterSpec extends FlatSpec with Matchers with MetricInspection with Gene
       val testCounter = Counter("test-counter")
       val incrMetric = IncrementMetric[IO, Counter].increment(testCounter)
       List.fill(expectedCounterValue)(incrMetric).sequence_.unsafeRunSync()
-      val actualCounterValue = Kamon.counter("test-counter").value()
+      val actualCounterValue = Kamon.counter("test-counter").withoutTags.value
       actualCounterValue shouldBe expectedCounterValue
     }
   }
@@ -27,7 +27,7 @@ class CounterSpec extends FlatSpec with Matchers with MetricInspection with Gene
     forAll(positiveInt) { expectedCounterValue: Int =>
       val testCounter = Counter("test-counter-2")
       IncrementMetric[IO, Counter].incrementTimes(expectedCounterValue.toLong)(testCounter).unsafeRunSync()
-      val actualCounterValue = Kamon.counter("test-counter-2").value()
+      val actualCounterValue = Kamon.counter("test-counter-2").withoutTags.value
       actualCounterValue shouldBe expectedCounterValue
     }
   }

--- a/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/GaugeSpec.scala
+++ b/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/GaugeSpec.scala
@@ -1,25 +1,25 @@
 package org.novelfs.taglessmetrics.kamon
 
 import _root_.kamon.Kamon
-import _root_.kamon.testkit.MetricInspection
+import _root_.kamon.testkit.InstrumentInspection
 import cats.effect.IO
 import cats.implicits._
-import org.novelfs.taglessmetrics.{DecrementMetric, IncrementMetric}
+import org.novelfs.taglessmetrics.{DecrementMetric, IncrementMetric, GaugeMetric}
 import org.novelfs.taglessmetrics.kamon.instances.all._
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
-import scala.concurrent.duration._
 
-class GaugeSpec extends FlatSpec with Matchers with MetricInspection with GeneratorDrivenPropertyChecks  {
+class GaugeSpec extends FlatSpec with Matchers with InstrumentInspection.Syntax with ScalaCheckDrivenPropertyChecks  {
   val positiveInt = Gen.posNum[Int]
+  val positiveDouble = Gen.posNum[Double]
 
   implicit val ioTimer = IO.timer(scala.concurrent.ExecutionContext.global)
 
   "increment" should "increment the metric the number of times it is called" in {
     forAll(positiveInt) { expectedGaugeValue: Int =>
-      val kamonGauge = Kamon.gauge("test-gauge")
-      kamonGauge.set(0)
+      val kamonGauge = Kamon.gauge("test-gauge").withoutTags
+      kamonGauge.update(0)
       val testGauge = Gauge("test-gauge")
       val incrMetric = IncrementMetric[IO, Gauge].increment(testGauge)
       List.fill(expectedGaugeValue)(incrMetric).sequence_.unsafeRunSync()
@@ -30,8 +30,8 @@ class GaugeSpec extends FlatSpec with Matchers with MetricInspection with Genera
 
   "incrementTimes" should "increment the metric by n" in {
     forAll(positiveInt) { expectedGaugeValue: Int =>
-      val kamonGauge = Kamon.gauge("test-gauge-2")
-      kamonGauge.set(0)
+      val kamonGauge = Kamon.gauge("test-gauge-2").withoutTags
+      kamonGauge.update(0)
       val testGauge = Gauge("test-gauge-2")
       IncrementMetric[IO, Gauge].incrementTimes(expectedGaugeValue.toLong)(testGauge).unsafeRunSync()
       val actualGaugeValue = kamonGauge.value()
@@ -41,8 +41,8 @@ class GaugeSpec extends FlatSpec with Matchers with MetricInspection with Genera
 
   "decrement" should "decrement the metric the number of times it is called" in {
     forAll(positiveInt) { n: Int =>
-      val kamonGauge = Kamon.gauge("test-gauge-3")
-      kamonGauge.set(Long.MaxValue)
+      val kamonGauge = Kamon.gauge("test-gauge-3").withoutTags
+      kamonGauge.update(Long.MaxValue)
       val testGauge = Gauge("test-gauge-3")
       val decrMetric = DecrementMetric[IO, Gauge].decrement(testGauge)
       List.fill(n)(decrMetric).sequence_.unsafeRunSync()
@@ -54,8 +54,8 @@ class GaugeSpec extends FlatSpec with Matchers with MetricInspection with Genera
 
   "decrementTimes" should "decrement the metric by n" in {
     forAll(positiveInt) { n: Int =>
-      val kamonGauge = Kamon.gauge("test-gauge-4")
-      kamonGauge.set(Long.MaxValue)
+      val kamonGauge = Kamon.gauge("test-gauge-4").withoutTags
+      kamonGauge.update(Long.MaxValue)
       val testGauge = Gauge("test-gauge-4")
       DecrementMetric[IO, Gauge].decrementTimes(n.toLong)(testGauge).unsafeRunSync()
       val expectedGaugeValue = Long.MaxValue - n
@@ -63,4 +63,28 @@ class GaugeSpec extends FlatSpec with Matchers with MetricInspection with Genera
       actualGaugeValue shouldBe expectedGaugeValue
     }
   }
+
+  "raise" should "raise the metric by n" in {
+    forAll(positiveDouble) { expectedGaugeValue: Double =>
+      val kamonGauge = Kamon.gauge("test-gauge-2").withoutTags
+      kamonGauge.update(0)
+      val testGauge = Gauge("test-gauge-2")
+      GaugeMetric[IO, Gauge].raise(expectedGaugeValue)(testGauge).unsafeRunSync()
+      val actualGaugeValue = kamonGauge.value()
+      actualGaugeValue shouldBe expectedGaugeValue
+    }
+  }
+
+  "lower" should "lower the metric by n" in {
+    forAll(positiveDouble) { n: Double =>
+      val kamonGauge = Kamon.gauge("test-gauge-4").withoutTags
+      kamonGauge.update(Double.MaxValue)
+      val testGauge = Gauge("test-gauge-4")
+      DecrementMetric[IO, Gauge].decrementTimes(n.toLong)(testGauge).unsafeRunSync()
+      val expectedGaugeValue = Double.MaxValue - n
+      val actualGaugeValue = kamonGauge.value()
+      actualGaugeValue shouldBe expectedGaugeValue
+    }
+  }
+
 }

--- a/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/HistogramSpec.scala
+++ b/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/HistogramSpec.scala
@@ -1,14 +1,13 @@
 package org.novelfs.taglessmetrics.kamon
 
-import cats.implicits._
-import kamon.testkit.MetricInspection
+import kamon.testkit.InstrumentInspection
 import org.scalatest.{FlatSpec, Matchers}
 import org.novelfs.taglessmetrics.kamon.instances.all._
 import _root_.kamon.Kamon
 import cats.effect.IO
 import org.novelfs.taglessmetrics.HistogramMetric
 
-class HistogramSpec extends FlatSpec with Matchers with MetricInspection {
+class HistogramSpec extends FlatSpec with Matchers with InstrumentInspection.Syntax {
   "histogram" should "record values" in {
     val hist = Histogram("test-histogram")
     val test =
@@ -20,7 +19,7 @@ class HistogramSpec extends FlatSpec with Matchers with MetricInspection {
 
     test.unsafeRunSync()
 
-    val kamonHist = Kamon.histogram("test-histogram")
+    val kamonHist = Kamon.histogram("test-histogram").withoutTags
 
     val distribution = kamonHist.distribution()
     distribution.min shouldBe 100

--- a/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/RangeSamplerSpec.scala
+++ b/kamon/src/test/scala/org/novelfs/taglessmetrics/kamon/RangeSamplerSpec.scala
@@ -1,18 +1,18 @@
 package org.novelfs.taglessmetrics.kamon
 
 import _root_.kamon.Kamon
-import _root_.kamon.testkit.MetricInspection
+import _root_.kamon.testkit.InstrumentInspection
 import cats.effect.IO
 import cats.implicits._
 import org.novelfs.taglessmetrics.kamon.instances.all._
-import org.novelfs.taglessmetrics.{DecrementMetric, IncrementMetric}
+import org.novelfs.taglessmetrics.IncrementMetric
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
 
-class RangeSamplerSpec extends FlatSpec with Matchers with MetricInspection with GeneratorDrivenPropertyChecks  {
+class RangeSamplerSpec extends FlatSpec with Matchers with InstrumentInspection.Syntax with ScalaCheckDrivenPropertyChecks  {
   val positiveInt = Gen.posNum[Int]
 
   implicit val ioTimer = IO.timer(scala.concurrent.ExecutionContext.global)
@@ -20,10 +20,11 @@ class RangeSamplerSpec extends FlatSpec with Matchers with MetricInspection with
   "increment" should "increment the metric the number of times it is called" in {
     forAll(positiveInt) { expectedRangeSamplerValue: Int =>
       val suffix = Random.alphanumeric.take(10).mkString
-      val kamonRangeSampler = Kamon.rangeSampler("test-range-sampler-" + suffix)
+      val kamonRangeSampler = Kamon.rangeSampler("test-range-sampler-" + suffix).withoutTags
       val testRangeSampler = RangeSampler("test-range-sampler-" + suffix)
       val incrMetric = IncrementMetric[IO, RangeSampler].increment(testRangeSampler)
       List.fill(expectedRangeSamplerValue)(incrMetric).sequence_.unsafeRunSync()
+      kamonRangeSampler.sample
       val actualRangeSamplerValue = kamonRangeSampler.distribution().max
       actualRangeSamplerValue shouldBe expectedRangeSamplerValue
     }
@@ -32,11 +33,13 @@ class RangeSamplerSpec extends FlatSpec with Matchers with MetricInspection with
   "incrementTimes" should "increment the metric by n" in {
     forAll(positiveInt) { expectedRangeSamplerValue: Int =>
       val suffix = Random.alphanumeric.take(10).mkString
-      val kamonRangeSampler = Kamon.rangeSampler("test-range-sampler-" + suffix)
+      val kamonRangeSampler = Kamon.rangeSampler("test-range-sampler-" + suffix).withoutTags
       val testRangeSampler = RangeSampler("test-range-sampler-" + suffix)
       IncrementMetric[IO, RangeSampler].incrementTimes(expectedRangeSamplerValue.toLong)(testRangeSampler).unsafeRunSync()
+      kamonRangeSampler.sample
       val actualRangeSamplerValue = kamonRangeSampler.distribution().max
       actualRangeSamplerValue shouldBe expectedRangeSamplerValue
     }
   }
+
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.11")


### PR DESCRIPTION
* Update Scala to 2.13.1, and Kamon to 2.0.4

  Updating Scala to 2.13 forces an upgrade of Kamon to 2.x because Kamon 1.x is only available up to 2.12.x. This has necessitated more changes than I'd initally anticipated because there have been some quite significant changes to Kamon in the 1.x to 2.x transition. In particular,

  * `refine` has been replaced by `withTag` which has three value type-specific variants
  * Collections of tags are now represented by a `TagSet` rather than a `Map`.
  * `Gauge`'s `increment` and `decrement` operations now take a `Double` rather than a `Long`.
  * A few other more minor API changes which only show up when working directly with the Kamon metrics, ie. here only in tests.

  I've dealt with the `Gauge` argument type switch to `Double` by adding a `GaugeMetric` interface with `raise`/`lower` operations which take `Double`s. The existing `Increment` and `Decrement` instances for `Gauge` are preserved and now convert their `Long` arguments to `Double`s before forwarding.

  I've dealt with the `refine` renaming and overloading by adding all three variants, named `withTag` to match the current Kamon API, to the metric wrappers.

 I'm afraid that because of the way that the Kamon changes unavoidably show through into the tagless-metrics API there's not much hope for usefully cross-building this between Scala 2.12 and 2.13. For now I've updated the documentation to reflect the state of things post this PR, but I would probably be worth preserving the old version for people still on 2.12/Kamon 1.x ... I'll do that if I get a :+1: on this general direction.

* Update SBT to 1.3.8
* Replace scalacOptions with sbt-tpolecat
* Update cats-effect to 2.1.0
* Update kind-projector to 0.11.0
* Update ScalaCheck to 1.14.3
* Update ScalaTest to 3.0.8